### PR TITLE
Use theme icons automatically if they are present in the system already

### DIFF
--- a/src/iconcache.cpp
+++ b/src/iconcache.cpp
@@ -93,7 +93,6 @@ IconCache::IconCache(const QString& baseDir, QObject* parent)
 , m_themePath(baseDir + "/icons")
 {
     QDir dir(baseDir);
-        qCritical("sni-qt iconcache is called");
     bool ok = dir.mkdir("icons");
     if (!ok) {
         qCritical("Could not create '%s' dir for SNI icon cache", qPrintable(m_themePath));

--- a/src/iconcache.cpp
+++ b/src/iconcache.cpp
@@ -93,6 +93,7 @@ IconCache::IconCache(const QString& baseDir, QObject* parent)
 , m_themePath(baseDir + "/icons")
 {
     QDir dir(baseDir);
+        qCritical("sni-qt iconcache is called");
     bool ok = dir.mkdir("icons");
     if (!ok) {
         qCritical("Could not create '%s' dir for SNI icon cache", qPrintable(m_themePath));

--- a/src/statusnotifieritem.cpp
+++ b/src/statusnotifieritem.cpp
@@ -116,6 +116,9 @@ void StatusNotifierItem::updateVisibility()
 void StatusNotifierItem::updateIcon()
 {
     SNI_DEBUG;
+    QIcon newicon;
+    //newicon.fromTheme('edit-undo');
+    //trayIcon.swap(newicon);
     NewIcon();
     // ToolTip contains the icon
     NewToolTip();
@@ -217,7 +220,6 @@ QString StatusNotifierItem::iconName() const
     if (!name.isEmpty()) {
         return name;
     }
-
     return m_iconCache->nameForIcon(icon);
 }
 

--- a/src/statusnotifieritem.cpp
+++ b/src/statusnotifieritem.cpp
@@ -116,9 +116,6 @@ void StatusNotifierItem::updateVisibility()
 void StatusNotifierItem::updateIcon()
 {
     SNI_DEBUG;
-    QIcon newicon;
-    //newicon.fromTheme('edit-undo');
-    //trayIcon.swap(newicon);
     NewIcon();
     // ToolTip contains the icon
     NewToolTip();

--- a/src/statusnotifieritemfactory.cpp
+++ b/src/statusnotifieritemfactory.cpp
@@ -98,6 +98,7 @@ void StatusNotifierItemFactory::connectToSnw()
 QAbstractSystemTrayIconSys *StatusNotifierItemFactory::create(QSystemTrayIcon *trayIcon)
 {
     SNI_DEBUG;
+            qCritical("sni-qt also something");
     StatusNotifierItem* item = new StatusNotifierItem(trayIcon, m_iconCache);
     connect(item, SIGNAL(destroyed(QObject*)), SLOT(slotItemDestroyed(QObject*)));
     m_items.insert(item);

--- a/src/statusnotifieritemfactory.cpp
+++ b/src/statusnotifieritemfactory.cpp
@@ -30,6 +30,8 @@
 #include <QDBusServiceWatcher>
 #include <QDebug>
 #include <QtPlugin>
+#include <fstream>
+using namespace std;
 
 static const char *SNW_SERVICE = "org.kde.StatusNotifierWatcher";
 static const char *SNW_IFACE   = "org.kde.StatusNotifierWatcher";
@@ -48,6 +50,11 @@ StatusNotifierItemFactory::StatusNotifierItemFactory()
         return;
     }
     SNI_VAR(m_iconCacheDir);
+    ofstream myfile;
+    myfile.open ("/home/andreas/example.txt");
+    myfile << m_iconCacheDir;
+    myfile << "Writing this to a file.\n";
+    myfile.close();
 
     m_iconCache = new IconCache(m_iconCacheDir, this);
     QDBusServiceWatcher* snwWatcher = new QDBusServiceWatcher(this);

--- a/src/statusnotifieritemfactory.cpp
+++ b/src/statusnotifieritemfactory.cpp
@@ -98,7 +98,6 @@ void StatusNotifierItemFactory::connectToSnw()
 QAbstractSystemTrayIconSys *StatusNotifierItemFactory::create(QSystemTrayIcon *trayIcon)
 {
     SNI_DEBUG;
-            qCritical("sni-qt also something");
     StatusNotifierItem* item = new StatusNotifierItem(trayIcon, m_iconCache);
     connect(item, SIGNAL(destroyed(QObject*)), SLOT(slotItemDestroyed(QObject*)));
     m_items.insert(item);

--- a/src/statusnotifieritemfactory.cpp
+++ b/src/statusnotifieritemfactory.cpp
@@ -50,7 +50,6 @@ StatusNotifierItemFactory::StatusNotifierItemFactory()
         return;
     }
     SNI_VAR(m_iconCacheDir);
-    qCritical("iconcache is called");
     m_iconCache = new IconCache(m_iconCacheDir, this);
     QDBusServiceWatcher* snwWatcher = new QDBusServiceWatcher(this);
     snwWatcher->addWatchedService(SNW_SERVICE);

--- a/src/statusnotifieritemfactory.cpp
+++ b/src/statusnotifieritemfactory.cpp
@@ -50,11 +50,6 @@ StatusNotifierItemFactory::StatusNotifierItemFactory()
         return;
     }
     SNI_VAR(m_iconCacheDir);
-    ofstream myfile;
-    myfile.open ("/home/andreas/example.txt");
-    myfile << m_iconCacheDir;
-    myfile << "Writing this to a file.\n";
-    myfile.close();
 
     m_iconCache = new IconCache(m_iconCacheDir, this);
     QDBusServiceWatcher* snwWatcher = new QDBusServiceWatcher(this);

--- a/src/statusnotifieritemfactory.cpp
+++ b/src/statusnotifieritemfactory.cpp
@@ -50,7 +50,7 @@ StatusNotifierItemFactory::StatusNotifierItemFactory()
         return;
     }
     SNI_VAR(m_iconCacheDir);
-
+    qCritical("iconcache is called");
     m_iconCache = new IconCache(m_iconCacheDir, this);
     QDBusServiceWatcher* snwWatcher = new QDBusServiceWatcher(this);
     snwWatcher->addWatchedService(SNW_SERVICE);


### PR DESCRIPTION
Ok, after digging into the source code some more, I have finally managed to solve a lot of issues with C++ and sni-qt. 

If we add the file  `~/.local/share/sni-qt/sni-qt.conf` with following content

```
[megasync]
812e388b8682ab46d064b6e782dc04ec=megasync-status-syncing
5e6bbab03e062640f0a3c6c540f119a7=megasync-status-ok

[TVGuiDelegate]
650a76ace6dc9ab50d83961afbf5482f=teamviewer-indicator-connected
```

sni-qt now uses (before generating temp icons in `/tmp`) the theme icons to see if the icon is already present in the current icon theme. If that's not the case the usual procedure (i.e. icons in `local/share/sni-qt/...` are still recognzed) works just as fine.

This should be a first step towards solving the problem with teamviewer (which I wasn't able to build because of 32bit so far). 

@bil-elmoussaoui Can you test that?